### PR TITLE
Use active span in client middleware and add propagation option

### DIFF
--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -1,3 +1,4 @@
+# Modified by SignalFx
 require "sidekiq"
 
 require "sidekiq/tracer/version"
@@ -9,23 +10,23 @@ require "sidekiq/tracer/server_middleware"
 module Sidekiq
   module Tracer
     class << self
-      def instrument(tracer: OpenTracing.global_tracer, active_span: nil)
-        instrument_client(tracer: tracer, active_span: active_span)
-        instrument_server(tracer: tracer, active_span: active_span)
+      def instrument(tracer: OpenTracing.global_tracer)
+        instrument_client(tracer: tracer)
+        instrument_server(tracer: tracer)
       end
 
-      def instrument_client(tracer: OpenTracing.global_tracer, active_span: nil)
+      def instrument_client(tracer: OpenTracing.global_tracer)
         Sidekiq.configure_client do |config|
           config.client_middleware do |chain|
-            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span
+            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer
           end
         end
       end
 
-      def instrument_server(tracer: OpenTracing.global_tracer, active_span: nil)
+      def instrument_server(tracer: OpenTracing.global_tracer)
         Sidekiq.configure_server do |config|
           config.client_middleware do |chain|
-            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, active_span: active_span
+            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer
           end
 
           config.server_middleware do |chain|

--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -10,33 +10,33 @@ require "sidekiq/tracer/server_middleware"
 module Sidekiq
   module Tracer
     class << self
-      def instrument(tracer: OpenTracing.global_tracer)
-        instrument_client(tracer: tracer)
-        instrument_server(tracer: tracer)
+      def instrument(tracer: OpenTracing.global_tracer, opts: {})
+        instrument_client(tracer: tracer, opts: opts)
+        instrument_server(tracer: tracer, opts: opts)
       end
 
-      def instrument_client(tracer: OpenTracing.global_tracer)
+      def instrument_client(tracer: OpenTracing.global_tracer, opts: {})
         Sidekiq.configure_client do |config|
           config.client_middleware do |chain|
-            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer
+            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, opts: opts
           end
         end
       end
 
-      def instrument_server(tracer: OpenTracing.global_tracer)
+      def instrument_server(tracer: OpenTracing.global_tracer, opts: {})
         Sidekiq.configure_server do |config|
           config.client_middleware do |chain|
-            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer
+            chain.add Sidekiq::Tracer::ClientMiddleware, tracer: tracer, opts: opts
           end
 
           config.server_middleware do |chain|
-            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer
+            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, opts: opts
           end
         end
 
         if defined?(Sidekiq::Testing)
           Sidekiq::Testing.server_middleware do |chain|
-            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer
+            chain.add Sidekiq::Tracer::ServerMiddleware, tracer: tracer, opts: opts
           end
         end
       end

--- a/lib/sidekiq/tracer.rb
+++ b/lib/sidekiq/tracer.rb
@@ -1,5 +1,6 @@
 # Modified by SignalFx
 require "sidekiq"
+require "opentracing"
 
 require "sidekiq/tracer/version"
 require "sidekiq/tracer/constants"

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -1,3 +1,4 @@
+# Modified by SignalFx
 module Sidekiq
   module Tracer
     class ClientMiddleware
@@ -5,27 +6,24 @@ module Sidekiq
 
       attr_reader :tracer, :active_span
 
-      def initialize(tracer:, active_span:)
+      def initialize(tracer: nil)
         @tracer = tracer
-        @active_span = active_span
       end
 
       def call(worker_class, job, queue, redis_pool)
-        span = tracer.start_span(operation_name(job),
-                                 child_of: active_span.respond_to?(:call) ? active_span.call : active_span,
-                                 tags: tags(job, 'client'))
-
-        inject(span, job)
-
+        scope = tracer.start_active_span(
+          operation_name(job), tags: tags(job, 'client')
+        )
+        inject(scope.span, job)
         yield
       rescue Exception => e
-        if span
-          span.set_tag('error', true)
-          span.log(event: 'error', :'error.object' => e)
+        if scope
+          scope.span.set_tag('error', true)
+          scope.span.log_kv(event: 'error', :'error.object' => e)
         end
         raise
       ensure
-        span.finish if span
+        scope.close if scope
       end
 
       private

--- a/lib/sidekiq/tracer/server_middleware.rb
+++ b/lib/sidekiq/tracer/server_middleware.rb
@@ -4,14 +4,15 @@ module Sidekiq
     class ServerMiddleware
       include Commons
 
-      attr_reader :tracer
+      attr_reader :tracer, :opts
 
-      def initialize(tracer: nil)
+      def initialize(tracer: nil, opts: {})
         @tracer = tracer
+        @opts = opts
       end
 
       def call(worker, job, queue)
-        parent_span_context = extract(job)
+        parent_span_context = extract(job) if opts.fetch(:propagate_context, true)
 
         scope = tracer.start_active_span(
           operation_name(job),

--- a/lib/sidekiq/tracer/server_middleware.rb
+++ b/lib/sidekiq/tracer/server_middleware.rb
@@ -1,3 +1,4 @@
+# Modified by SignalFx
 module Sidekiq
   module Tracer
     class ServerMiddleware
@@ -5,7 +6,7 @@ module Sidekiq
 
       attr_reader :tracer
 
-      def initialize(tracer:)
+      def initialize(tracer: nil)
         @tracer = tracer
       end
 
@@ -22,7 +23,7 @@ module Sidekiq
       rescue Exception => e
         if scope
           scope.span.set_tag('error', true)
-          scope.span.log(event: 'error', :'error.object' => e)
+          scope.span.log_kv(event: 'error', :'error.object' => e)
         end
         raise
       ensure

--- a/spec/sidekiq/tracer/client_middleware_spec.rb
+++ b/spec/sidekiq/tracer/client_middleware_spec.rb
@@ -86,6 +86,18 @@ RSpec.describe Sidekiq::Tracer::ClientMiddleware do
     end
   end
 
+  describe "disabling span context injection"  do
+    before do
+      Sidekiq::Tracer.instrument_client(tracer: tracer, opts: {propagate_context: false})
+      schedule_test_job
+    end
+
+    it "doesn't inject span context to enqueued job" do
+      job = TestJob.jobs.last
+      expect(job['Trace-Context']).to be(nil)
+    end
+  end
+
   def schedule_test_job
     TestJob.perform_async("value1", "value2", 1)
   end


### PR DESCRIPTION
These changes allow client middleware spans to be created from the active span, if any.  They also add a new options argument that will allow `:propagate_context => false` to prevent context injection and extraction attempts in the job metadata, if undesired.