### PR TITLE
Truncate sidekiq.args tag to 1024 chars

### DIFF
--- a/lib/sidekiq/tracer/commons.rb
+++ b/lib/sidekiq/tracer/commons.rb
@@ -12,7 +12,7 @@ module Sidekiq
           'sidekiq.queue' => job['queue'],
           'sidekiq.jid' => job['jid'],
           'sidekiq.retry' => job['retry'].to_s,
-          'sidekiq.args' => job['args'].join(", ")
+          'sidekiq.args' => job['args'].join(", ")[0, 1024]
         }
       end
     end

--- a/spec/sidekiq/tracer/client_middleware_spec.rb
+++ b/spec/sidekiq/tracer/client_middleware_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Sidekiq::Tracer::ClientMiddleware do
       expect(span.tags).to include(
         'sidekiq.queue' => 'default',
         'sidekiq.retry' => 'true',
-        'sidekiq.args' => 'value1, value2, 1',
+        'sidekiq.args' => 'value1, value2' + ('2' * 1010),
         'sidekiq.jid' => /\S+/
       )
     end
@@ -99,7 +99,7 @@ RSpec.describe Sidekiq::Tracer::ClientMiddleware do
   end
 
   def schedule_test_job
-    TestJob.perform_async("value1", "value2", 1)
+    TestJob.perform_async("value1", "value" + "2" * 1024, 1)
   end
 
   class TestJob

--- a/spec/sidekiq/tracer/server_middleware_spec.rb
+++ b/spec/sidekiq/tracer/server_middleware_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
       expect(span.tags).to include(
         'sidekiq.queue' => 'default',
         'sidekiq.retry' => 'true',
-        'sidekiq.args' => 'value1, value2, 1',
+        'sidekiq.args' => 'value1, value2' + ('2' * 1010),
         'sidekiq.jid' => /\S+/
       )
     end
@@ -117,7 +117,7 @@ RSpec.describe Sidekiq::Tracer::ServerMiddleware do
 
 
   def schedule_test_job
-    TestJob.perform_async("value1", "value2", 1)
+    TestJob.perform_async("value1", "value" + "2" * 1024, 1)
   end
 
   class TestJob


### PR DESCRIPTION
Current tag length is unbounded, which can be problematic in many cases.