### PR TITLE
Fallback to standard span handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
-  - 2.4
-before_install: gem install bundler -v 1.15.4
+  - 2.5
+  - 2.6
+  - 2.7
+  - 3.0
+before_install: gem install bundler -v 2.2.5

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -6,9 +6,16 @@ module Sidekiq
 
       attr_reader :tracer, :opts
 
-      def initialize(tracer: nil, opts: {})
-        @tracer = tracer
-        @opts = opts
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+        def initialize(args)
+          @tracer = args[:tracer]
+          @opts = args.fetch(:opts, {})
+        end
+      else
+        def initialize(tracer: nil, opts: {})
+          @tracer = tracer
+          @opts = opts
+        end
       end
 
       def call(worker_class, job, queue, redis_pool)

--- a/lib/sidekiq/tracer/client_middleware.rb
+++ b/lib/sidekiq/tracer/client_middleware.rb
@@ -25,9 +25,14 @@ module Sidekiq
         inject(scope.span, job) if opts.fetch(:propagate_context, true)
         yield
       rescue Exception => e
-        if scope
+        if scope&.span.respond_to?(:record_exception)
+          # SignalFx custom error analyzer
           scope.span.record_exception(e)
+        elsif scope&.span
+          scope.span.set_tag('error', true)
+          scope.span.log_kv(event: 'error', :'error.object' => e)
         end
+
         raise
       ensure
         scope.close if scope

--- a/lib/sidekiq/tracer/server_middleware.rb
+++ b/lib/sidekiq/tracer/server_middleware.rb
@@ -6,9 +6,16 @@ module Sidekiq
 
       attr_reader :tracer, :opts
 
-      def initialize(tracer: nil, opts: {})
-        @tracer = tracer
-        @opts = opts
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+        def initialize(args)
+          @tracer = args[:tracer]
+          @opts = args.fetch(:opts, {})
+        end
+      else
+        def initialize(tracer: nil, opts: {})
+          @tracer = tracer
+          @opts = opts
+        end
       end
 
       def call(worker, job, queue)


### PR DESCRIPTION
https://github.com/iaintshine/ruby-sidekiq-tracer/commit/606c95c3ee7ca9c1dea47f597f85b6909cadc73f

This reverts to the previous `sidekiq-ruby-tracer` implementation if the custom handler is not available.

